### PR TITLE
change to the ps aux command

### DIFF
--- a/CHTC Student Handbook.tex
+++ b/CHTC Student Handbook.tex
@@ -189,7 +189,7 @@
                 \item Confirm condor is running: {\fontfamily{cmtt}\selectfont \$
                 condor\_status \$HOSTNAME }
                 \item You should also see Condor running with {\fontfamily{cmtt}\selectfont
-                \$ ps aux }
+                \$ ps aux | grep condor }
             \end{enumerate}
     \end{enumerate}
 \clearpage


### PR DESCRIPTION
changed $ ps aux to $ ps aux | grep condor
instead of getting a list of all processes you get a list of only the condor related ones.
